### PR TITLE
Fix tasks and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ This repository is heavily under development and unstable.
 - [ ] Support instagram photo
 - [ ] Support twitter card
 
+## Development
+
+```
+git clone git@github.com:bokuweb/tsukiakari.git
+cd tsukiakari
+npm install
+npm run dev
+```
+
 ## LICENSE
 
 ### Linearicons Free

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "A minimal Electron application",
   "main": "/src/browser/dist/bundle.js",
   "scripts": {
-    "dev": "electron src/browser/dist/bundle.js & npm run watch",
+    "dev": "npm run build:all && (electron src/browser/dist/bundle.js & npm run watch)",
     "start": "electron src/browser/dist/bundle.js",
+    "build:all": "npm run build:js && npm run build:stylus",
     "watch:js": "watchify src/renderer/src/index.js -o src/renderer/dist/bundle.js --ignore-missing",
     "build:js": "npm run build:renderer && npm run build:main",
     "build:renderer": "browserify --extension=js -o src/renderer/dist/bundle.js src/renderer/src/index.js --ignore-missing",


### PR DESCRIPTION
`build:all` task is needed to ensure CSS files are compiled before launching Electron. Because `dev` task is in race condition (`npm run watch` and `electron ...`), there is a possibility of that the app will launch without the stylesheet.
